### PR TITLE
Update cultivar.R

### DIFF
--- a/R/cultivar.R
+++ b/R/cultivar.R
@@ -160,7 +160,7 @@ update_cultivar <- function(l, df, add = TRUE, use_folder = TRUE,
     i <- 1
     for (i in seq(along = cultivars_name)) {
         df_cultivar <- df[df$name == cultivars_name[i],]
-        commands <- paste0(df_cultivar$parameter, " = ", df_cultivar$value)
+        commands <- as.list(paste0(df_cultivar$parameter, " = ", df_cultivar$value))
         # Search whether the cultivar existing
         cultivar_node <- search_path(l, paste0("[", cultivars_name[i], "]"))
         if (length(cultivar_node) != 0 &&


### PR DESCRIPTION
![6ac04e7fc48d1b9c5250cc39058ff598](https://github.com/user-attachments/assets/f0aefcf3-d44d-4dfd-b88c-d52df2103f6c)
The modification I made was to change the "Command" field from a single string to a list containing a string. Specifically, I changed:"Command": "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 60" to "Command": ["[Phenology].Phyllochron.BasePhyllochron.FixedValue = 20,45,60"] This modification, which involves enclosing the command string in square brackets [], effectively turns it into a list. This change allowed the model to run successfully, whereas the previous version with just a string did not work. The key point is that the command needs to be in a list format for the model to process it correctly.

